### PR TITLE
! dictionary resize was called twice in a row

### DIFF
--- a/OmniXML_Dictionary.pas
+++ b/OmniXML_Dictionary.pas
@@ -49,6 +49,7 @@ type
     {$ENDIF}
     FTextList: TStringList;
     FMaxItemsBeforeResize: Integer;
+    FLastHashSize: Integer;
     procedure Resize;
   public
     constructor Create; reintroduce;
@@ -171,7 +172,8 @@ var
 begin
   FHashTable.Free;
 
-  HashSize := GetGoodHashSize(FTextList.Count);
+  HashSize := GetGoodHashSize(FLastHashSize+1);
+  FLastHashSize := HashSize;
 
   {$IFDEF FPC}
   FHashTable := TFPHashList.Create;


### PR DESCRIPTION
test case:

dic := TDictionary.Create;
try
for i := 1 to 63 do
dic.Add(IntToStr(i));
// next two calls will both trigger Resize
dic.Add('64');
dic.Add('65');
for i := 66 to 127 do
dic.Add(IntToStr(i));
// next two calls will both trigger Resize
dic.Add('128');
dic.Add('129');
finally FreeAndNil(dic); end;