### PR TITLE
Change TOmniXMLReader.read behaviour

### DIFF
--- a/OmniXMLPersistent.pas
+++ b/OmniXMLPersistent.pas
@@ -485,9 +485,6 @@ end;
 
 constructor TOmniXMLReader.Create(const PropFormat: TPropsFormat = pfAuto);
 begin
-  if PropFormat = pfAuto then
-    raise EOmniXMLPersistent.Create('Auto PropFormat not allowed here.');
-
   PropsFormat := PropFormat;
 end;
 
@@ -509,25 +506,32 @@ begin
 end;
 
 function TOmniXMLReader.InternalReadText(Root: IXMLElement; Name: XmlString; var Value: XmlString): Boolean;
-var
-  PropNode: IXMLElement;
-  AttrNode: IXMLNode;
+
+  function ReadNodes: Boolean;
+  var
+    PropNode: IXMLElement;
+  begin
+    PropNode := FindElement(Root, Name);
+    Result := PropNode <> nil;
+    if Result then
+      Value := PropNode.Text;
+  end;
+
+  function ReadAttributes: Boolean;
+  var
+    AttrNode: IXMLNode;
+  begin
+    AttrNode := Root.Attributes.GetNamedItem(Name);
+    Result := AttrNode <> nil;
+    if Result then
+      Value := AttrNode.NodeValue;
+  end;
+
 begin
   case PropsFormat of
-    pfAttributes:
-      begin
-        AttrNode := Root.Attributes.GetNamedItem(Name);
-        Result := AttrNode <> nil;
-        if Result then
-          Value := AttrNode.NodeValue;
-      end;
-    pfNodes:
-      begin
-        PropNode := FindElement(Root, Name);
-        Result := PropNode <> nil;
-        if Result then
-          Value := PropNode.Text;
-      end;
+    pfAttributes: Result := ReadAttributes();
+    pfNodes: Result := ReadNodes();
+    pfAuto:  Result := (ReadNodes() or ReadAttributes)
     else
       Result := False;
   end;


### PR DESCRIPTION
When deserializing objects, from documents that were generated in third party code the situation may occur, when stored properties are mixed in XML attributes and nodes. I suggest:
 * Mode pfAuto is used for reading data in mixed situation;
 * Priority of match is hardcoded to nodes. If no corresponding xml node found attributes are scanned for matching object property.

Respect and greetings to @mremec, @the-Arioch, @gabr42