### PR TITLE
Fix for cdata containing two closing square brackets

### DIFF
--- a/OmniXML.pas
+++ b/OmniXML.pas
@@ -3309,7 +3309,7 @@ procedure TXMLCDATASection.ReadFromStream(const Parent: TXMLNode; const InputStr
 type
   TParserState = (psData, psInEnd, psEnd);
 var
-  ReadChar: WideChar;
+  ReadChar: XmlChar;
   PState: TParserState;
 begin
   PState := psData;

--- a/OmniXML.pas
+++ b/OmniXML.pas
@@ -3309,7 +3309,7 @@ procedure TXMLCDATASection.ReadFromStream(const Parent: TXMLNode; const InputStr
 type
   TParserState = (psData, psInEnd, psEnd);
 var
-  ReadChar: XmlChar;
+  ReadChar: WideChar;
   PState: TParserState;
 begin
   PState := psData;
@@ -3339,11 +3339,14 @@ begin
         end
         else
         begin
-          InputStream.WriteOutputChar(ReadChar);
+          InputStream.WriteOutputChar(']');
           if ReadChar = ']' then
             PState := psEnd
-          else
+          else begin
+            InputStream.WriteOutputChar(']');
+            InputStream.WriteOutputChar(ReadChar);
             PState := psData;
+          end;
         end;
     end;
   end;


### PR DESCRIPTION
Parsing CDATA containing two closing square brackets did not work:
'asdf ]] blub' is encoded as '<![CDATA[asdf ]] blub]]>' but read back as 'asdf  blub'.
This is now fixed.